### PR TITLE
GH action: Fix for Python 3.6

### DIFF
--- a/.github/workflows/python-36-tests.yaml
+++ b/.github/workflows/python-36-tests.yaml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Tests Runner
+name: Python 3.6 Tests Runner
 
 on:
   push:
@@ -12,11 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.6"]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,9 +31,3 @@ jobs:
     - name: Run Tests with unittest
       run: |
         python -m unittest discover -s tests
-#     - name: Lint with flake8
-#       run: |
-#         # stop the build if there are Python syntax errors or undefined names
-#         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/neurox/analysis/plotting.py
+++ b/neurox/analysis/plotting.py
@@ -6,6 +6,7 @@ import seaborn as sns
 sns.set(style="darkgrid")
 sns.set_palette("tab10")
 
+
 ### Plotting
 def plot_accuracies_per_tag(title, **kwargs):
     if kwargs is None:

--- a/neurox/data/utils.py
+++ b/neurox/data/utils.py
@@ -50,7 +50,6 @@ def save_files(
     decompose_layers=False,
     filter_layers=None,
 ):
-
     """
     Save word and label files in the text format and activations in the specified format (default hdf5 format)
 

--- a/neurox/interpretation/gaussian_probe.py
+++ b/neurox/interpretation/gaussian_probe.py
@@ -42,7 +42,6 @@ class GaussianProbe:
         self.categorical_sets["train"] = self.train_categorical
 
     def _get_categorical(self, set_name):
-
         counts = torch.histc(self.label_sets[set_name].float(), bins=self.labels_dim)
         categorical = (counts / self.label_sets[set_name].size()[0]).to(self.device)
         return categorical

--- a/neurox/interpretation/probeless.py
+++ b/neurox/interpretation/probeless.py
@@ -12,7 +12,6 @@ import numpy as np
 
 
 def _get_mean_vectors(X_train, y_train):
-
     embeddings_by_labels = {}
     average_embeddings_by_label = {}
     rankings_per_label = {}
@@ -35,7 +34,6 @@ def _get_mean_vectors(X_train, y_train):
 
 
 def _get_overall_ranking(mean_vectors):
-
     overall = np.zeros_like(mean_vectors[0])
 
     for couple in itertools.combinations(mean_vectors, 2):
@@ -46,12 +44,10 @@ def _get_overall_ranking(mean_vectors):
 
 
 def _get_tag_wise_ranking(mean_vectors_by_label, tag):
-
     qz = mean_vectors_by_label[tag]
     summation = np.abs(np.subtract(qz, qz))
 
     for c, qzz in mean_vectors_by_label.items():
-
         if tag != c:
             summation = np.add(summation, np.abs(np.subtract(qz, qzz)))
 
@@ -147,7 +143,6 @@ def get_neuron_ordering_for_all_tags(X_train, y_train, idx2label):
     overall = np.zeros_like(X_train[0])
 
     for c, qz in average_embeddings_by_label.items():
-
         summation, ranking = _get_tag_wise_ranking(average_embeddings_by_label, c)
         overall = np.add(overall, summation)
         ranking_per_tag[idx2label[c]] = ranking


### PR DESCRIPTION
Python 3.6 is no longer available on `ubuntu-latest`, so we need to specify an older version for Python 3.6 tests. 